### PR TITLE
🧹 fix AI move selection across multiple mini-boards

### DIFF
--- a/lib/logica/jogo_ia.dart
+++ b/lib/logica/jogo_ia.dart
@@ -22,17 +22,19 @@ class JogoIA {
   }
 
   int escolherJogada(SuperJogoDaVelhaLogica jogoLogica) {
-    int melhorValor = -1000;
+    int melhorValor = -1001;
     int melhorJogada = -1;
 
     if (jogoLogica.proximoMiniTabuleiroLinha != -1 && jogoLogica.proximoMiniTabuleiroColuna != -1) {
-      melhorJogada = avaliarPosicoesNoMiniTabuleiro(jogoLogica, jogoLogica.proximoMiniTabuleiroLinha, jogoLogica.proximoMiniTabuleiroColuna, melhorValor);
+      var (jogada, valor) = avaliarPosicoesNoMiniTabuleiro(jogoLogica, jogoLogica.proximoMiniTabuleiroLinha, jogoLogica.proximoMiniTabuleiroColuna, melhorValor);
+      melhorJogada = jogada;
     } else {
       for (int linha = 0; linha < 3; linha++) {
         for (int coluna = 0; coluna < 3; coluna++) {
           if (jogoLogica.vencedoresMiniTabuleiros[linha][coluna] == '') {
-            int jogadaAtual = avaliarPosicoesNoMiniTabuleiro(jogoLogica, linha, coluna, melhorValor);
-            if (jogadaAtual != -1 && jogoLogica.tabuleiro[linha][coluna][jogadaAtual % 9] == '') {
+            var (jogadaAtual, valorAtual) = avaliarPosicoesNoMiniTabuleiro(jogoLogica, linha, coluna, melhorValor);
+            if (jogadaAtual != -1 && valorAtual > melhorValor) {
+              melhorValor = valorAtual;
               melhorJogada = jogadaAtual;
             }
           }
@@ -43,8 +45,9 @@ class JogoIA {
     return melhorJogada;
   }
 
-  int avaliarPosicoesNoMiniTabuleiro(SuperJogoDaVelhaLogica jogoLogica, int linha, int coluna, int melhorValor) {
+  (int, int) avaliarPosicoesNoMiniTabuleiro(SuperJogoDaVelhaLogica jogoLogica, int linha, int coluna, int melhorValorBase) {
     int melhorJogada = -1;
+    int melhorValor = melhorValorBase;
     for (int posicao = 0; posicao < 9; posicao++) {
       if (jogoLogica.tabuleiro[linha][coluna][posicao] == '') {
         jogoLogica.tabuleiro[linha][coluna][posicao] = jogadorIA;
@@ -56,7 +59,7 @@ class JogoIA {
         }
       }
     }
-    return melhorJogada;
+    return (melhorJogada, melhorValor);
   }
 
   int calcularPontuacao(SuperJogoDaVelhaLogica jogoLogica, int linha, int coluna, int posicao) {

--- a/test/jogo_ia_test.dart
+++ b/test/jogo_ia_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superjogodavelha/controle/jogo_controle.dart';
+import 'package:superjogodavelha/logica/jogo_ia.dart';
+import 'package:superjogodavelha/logica/jogo_logica.dart';
+
+void main() {
+  group('JogoIA Tests', () {
+    late JogoController controller;
+    late JogoIA ia;
+    late SuperJogoDaVelhaLogica logica;
+
+    setUp(() {
+      controller = JogoController();
+      ia = controller.jogoIA;
+      ia.profundidadeMaxima = 1;
+      logica = controller.jogoLogica;
+    });
+
+    test('avaliarPosicoesNoMiniTabuleiro should return a move if it exists', () {
+      var (jogada, valor) = ia.avaliarPosicoesNoMiniTabuleiro(logica, 0, 0, -1001);
+      expect(jogada, isNot(-1));
+    });
+
+    test('escolherJogada should pick a winning move if available', () {
+      logica.proximoMiniTabuleiroLinha = 0;
+      logica.proximoMiniTabuleiroColuna = 0;
+      logica.tabuleiro[0][0][0] = 'O';
+      logica.tabuleiro[0][0][1] = 'O';
+
+      int jogada = ia.escolherJogada(logica);
+      expect(jogada, 2);
+    });
+
+    test('escolherJogada should pick the best move across all mini-tabuleiros', () {
+      logica.reiniciarJogo();
+      ia.profundidadeMaxima = 1;
+      logica.proximoMiniTabuleiroLinha = -1;
+      logica.proximoMiniTabuleiroColuna = -1;
+      logica.tabuleiro[0][0][0] = 'O';
+      logica.tabuleiro[0][0][1] = 'O';
+
+      int jogada = ia.escolherJogada(logica);
+      expect(jogada, 2);
+    });
+  });
+}


### PR DESCRIPTION
The AI logic in `lib/logica/jogo_ia.dart` had a bug where `melhorValor` was passed by value to `avaliarPosicoesNoMiniTabuleiro`. This meant that when the AI could play on any mini-board, it would often pick a move from the last evaluated board even if an earlier board had a much better move, because the "best value" found so far wasn't being propagated back to the main loop.

I refactored the code to use Dart Records `(int, int)` to return both the best move and its value from `avaliarPosicoesNoMiniTabuleiro`. I also updated the loop in `escolherJogada` to correctly update the local `melhorValor` with the value returned from each mini-board evaluation.

Additionally, I added a test suite `test/jogo_ia_test.dart` that specifically reproduces this scenario and confirms the fix.

---
*PR created automatically by Jules for task [9614022846961428039](https://jules.google.com/task/9614022846961428039) started by @ethyios*